### PR TITLE
Propagate error string on failed run

### DIFF
--- a/fn.go
+++ b/fn.go
@@ -120,7 +120,7 @@ func (f *Function) RunFunction(_ context.Context, req *fnv1.RunFunctionRequest) 
 	cmd.Stderr = &stderr
 	err = cmd.Run()
 	if err != nil {
-		response.Fatal(rsp, errors.Wrapf(err, "shellCmd %s for %s failed", shellCmd, oxr.Resource.GetKind()))
+		response.Fatal(rsp, errors.Wrapf(err, "shellCmd %s for %s failed with error: %s", shellCmd, oxr.Resource.GetKind(), stderr.String()))
 		return rsp, nil
 	}
 	out := strings.TrimSpace(stdout.String())

--- a/fn_test.go
+++ b/fn_test.go
@@ -129,7 +129,7 @@ func TestRunFunction(t *testing.T) {
 					Input: resource.MustStructJSON(`{
 						"apiVersion": "template.fn.crossplane.io/v1alpha1",
 						"kind": "Parameters",
-						"shellCommand": "unkown-shell-command",
+						"shellCommand": "unknown-shell-command",
 						"stdoutField": "spec.atFunction.shell.stdout",
 						"stderrField": "spec.atFunction.shell.stderr"
 					}`),
@@ -141,7 +141,7 @@ func TestRunFunction(t *testing.T) {
 					Results: []*fnv1.Result{
 						{
 							Severity: fnv1.Severity_SEVERITY_FATAL,
-							Message:  "shellCmd unkown-shell-command for  failed: exit status 127",
+							Message:  "shellCmd unknown-shell-command for  failed with error: /bin/sh: unknown-shell-command: command not found\n: exit status 127",
 							Target:   fnv1.Target_TARGET_COMPOSITE.Enum(),
 						},
 					},


### PR DESCRIPTION
# Description of your changes

Propagate error string if a command run results in an error. 

Fixes #

I have:

- [ ] Read and followed Crossplane's
[contribution process][contribution process]. Also see [docs][docs].
- [ ] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
