### PR TITLE
Enable debugging on Docker builds 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,7 @@ jobs:
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
+          buildkitd-flags: --debug
           version: ${{ env.DOCKER_BUILDX_VERSION }}
           install: true
 


### PR DESCRIPTION
# Description of your changes

The Docker build is embedding x86 binaries and libraries in the arm build. Enable debugging on the docker build process. 

Fixes #

I have:

- [ ] Read and followed Crossplane's
[contribution process][contribution process]. Also see [docs][docs].
- [ ] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
