### PR TITLE
Add TTL support for function caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ kubeconfig
 function-shell
 function-amd64.xpkg
 function-arm64.xpkg
+
+# OS files
+.DS_Store

--- a/example/echo/composition.yaml
+++ b/example/echo/composition.yaml
@@ -14,6 +14,7 @@ spec:
       input:
         apiVersion: shell.fn.crossplane.io/v1alpha1
         kind: Parameters
+        cacheTTL: 5m
         shellEnvVars:
           - key: ECHO
             value: "SGVsbG8gZnJvbSBzaGVsbAo="

--- a/fn.go
+++ b/fn.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"strings"
+	"time"
 
 	"github.com/crossplane-contrib/function-shell/input/v1alpha1"
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
@@ -12,6 +13,7 @@ import (
 	"github.com/crossplane/function-sdk-go/request"
 	"github.com/crossplane/function-sdk-go/response"
 	"github.com/keegancsmith/shell"
+	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 // Function returns whatever response you ask it to.
@@ -31,6 +33,15 @@ func (f *Function) RunFunction(_ context.Context, req *fnv1.RunFunctionRequest) 
 	if err := request.GetInput(req, in); err != nil {
 		response.Fatal(rsp, errors.Wrapf(err, "cannot get Function from input"))
 		return rsp, nil
+	}
+
+	if in.CacheTTL != "" {
+		dur, err := time.ParseDuration(in.CacheTTL)
+		if err != nil {
+			response.Fatal(rsp, errors.Wrapf(err, "cannot set cacheTTL"))
+			return rsp, nil
+		}
+		rsp.Meta.Ttl = durationpb.New(dur)
 	}
 
 	oxr, err := request.GetObservedCompositeResource(req)

--- a/fn_test.go
+++ b/fn_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -185,6 +186,75 @@ func TestRunFunction(t *testing.T) {
 									}
 								}
 							}`),
+						},
+					},
+				},
+			},
+		},
+		"ResponseWithCustomCacheTTL": {
+			reason: "The Function should set custom TTL when cacheTTL is specified",
+			args: args{
+				req: &fnv1.RunFunctionRequest{
+					Meta: &fnv1.RequestMeta{Tag: "hello"},
+					Input: resource.MustStructJSON(`{
+						"apiVersion": "template.fn.crossplane.io/v1alpha1",
+						"kind": "Parameters",
+						"shellCommand": "echo test",
+						"cacheTTL": "5m",
+						"stdoutField": "spec.atFunction.shell.stdout"
+					}`),
+				},
+			},
+			want: want{
+				rsp: &fnv1.RunFunctionResponse{
+					Meta: &fnv1.ResponseMeta{Tag: "hello", Ttl: durationpb.New(5 * time.Minute)},
+					Desired: &fnv1.State{
+						Composite: &fnv1.Resource{
+							Resource: resource.MustStructJSON(`{
+								"apiVersion": "",
+								"kind": "",
+								"spec": {
+									"atFunction": {
+										"shell": {
+											"stdout": "test"
+										}
+									}
+								},
+								"status": {
+									"atFunction": {
+										"shell": {
+											"stderr": ""
+										}
+									}
+								}
+							}`),
+						},
+					},
+				},
+			},
+		},
+		"ResponseWithInvalidCacheTTL": {
+			reason: "The Function should return a fatal error when cacheTTL has invalid format",
+			args: args{
+				req: &fnv1.RunFunctionRequest{
+					Meta: &fnv1.RequestMeta{Tag: "hello"},
+					Input: resource.MustStructJSON(`{
+						"apiVersion": "template.fn.crossplane.io/v1alpha1",
+						"kind": "Parameters",
+						"shellCommand": "echo test",
+						"cacheTTL": "5x",
+						"stdoutField": "spec.atFunction.shell.stdout"
+					}`),
+				},
+			},
+			want: want{
+				rsp: &fnv1.RunFunctionResponse{
+					Meta: &fnv1.ResponseMeta{Tag: "hello", Ttl: durationpb.New(response.DefaultTTL)},
+					Results: []*fnv1.Result{
+						{
+							Severity: fnv1.Severity_SEVERITY_FATAL,
+							Message:  `cannot set cacheTTL: time: unknown unit "x" in duration "5x"`,
+							Target:   fnv1.Target_TARGET_COMPOSITE.Enum(),
 						},
 					},
 				},

--- a/input/v1alpha1/parameters.go
+++ b/input/v1alpha1/parameters.go
@@ -42,6 +42,11 @@ type Parameters struct {
 	// stderrField
 	// +optional
 	StderrField string `json:"stderrField,omitempty"`
+
+	// TTL for response cache. Defaults to 1m
+	// +optional
+	// +kubebuilder:default:="1m"
+	CacheTTL string `json:"cacheTTL,omitempty"`
 }
 
 type ShellEnvVar struct {
@@ -53,6 +58,6 @@ type ShellEnvVar struct {
 type ShellEnvVarsRef struct {
 	// The Key whose value is the secret
 	Keys []string `json:"keys,omitempty"`
-	// Name of the enviroment variable
+	// Name of the environment variable
 	Name string `json:"name,omitempty"`
 }

--- a/package/input/template.fn.crossplane.io_parameters.yaml
+++ b/package/input/template.fn.crossplane.io_parameters.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: parameters.template.fn.crossplane.io
 spec:
   group: template.fn.crossplane.io
@@ -27,6 +27,10 @@ spec:
               Servers should convert recognized schemas to the latest internal value, and
               may reject unrecognized values.
               More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          cacheTTL:
+            default: 1m
+            description: TTL for response cache. Defaults to 1m
             type: string
           kind:
             description: |-
@@ -65,7 +69,7 @@ spec:
                   type: string
                 type: array
               name:
-                description: Name of the enviroment variable
+                description: Name of the environment variable
                 type: string
             type: object
           stderrField:


### PR DESCRIPTION
# Description of your changes

In Crossplane 1.20, the ability via PR <https://github.com/crossplane/crossplane/pull/6422> to cache function outputs was added as an alpha feature with the flag `--enable-function-response-cache `

This PR implements setting the TTL via the input using the `cacheTTL` field. 

Fixes #

I have:

- [ ] Read and followed Crossplane's
[contribution process][contribution process]. Also see [docs][docs].
- [ ] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
