### PR TITLE
Change apigroup

### DIFF
--- a/fn_test.go
+++ b/fn_test.go
@@ -39,7 +39,7 @@ func TestRunFunction(t *testing.T) {
 				req: &fnv1.RunFunctionRequest{
 					Meta: &fnv1.RequestMeta{Tag: "hello"},
 					Input: resource.MustStructJSON(`{
-						"apiVersion": "template.fn.crossplane.io/v1alpha1",
+						"apiVersion": "shell.fn.crossplane.io/v1alpha1",
 						"kind": "Parameters"
 					}`),
 				},
@@ -63,7 +63,7 @@ func TestRunFunction(t *testing.T) {
 				req: &fnv1.RunFunctionRequest{
 					Meta: &fnv1.RequestMeta{Tag: "hello"},
 					Input: resource.MustStructJSON(`{
-						"apiVersion": "template.fn.crossplane.io/v1alpha1",
+						"apiVersion": "shell.fn.crossplane.io/v1alpha1",
 						"kind": "Parameters",
 						"shellCommand": ""
 					}`),
@@ -88,7 +88,7 @@ func TestRunFunction(t *testing.T) {
 				req: &fnv1.RunFunctionRequest{
 					Meta: &fnv1.RequestMeta{Tag: "hello"},
 					Input: resource.MustStructJSON(`{
-						"apiVersion": "template.fn.crossplane.io/v1alpha1",
+						"apiVersion": "shell.fn.crossplane.io/v1alpha1",
 						"kind": "Parameters",
 						"shellCommand": "echo foo",
 						"stdoutField": "spec.atFunction.shell.stdout"
@@ -129,7 +129,7 @@ func TestRunFunction(t *testing.T) {
 				req: &fnv1.RunFunctionRequest{
 					Meta: &fnv1.RequestMeta{Tag: "hello"},
 					Input: resource.MustStructJSON(`{
-						"apiVersion": "template.fn.crossplane.io/v1alpha1",
+						"apiVersion": "shell.fn.crossplane.io/v1alpha1",
 						"kind": "Parameters",
 						"shellCommand": "set -euo pìpefail",
 						"stdoutField": "status.atFunction.shell.stdout",
@@ -173,7 +173,7 @@ func TestRunFunction(t *testing.T) {
 				req: &fnv1.RunFunctionRequest{
 					Meta: &fnv1.RequestMeta{Tag: "hello"},
 					Input: resource.MustStructJSON(`{
-						"apiVersion": "template.fn.crossplane.io/v1alpha1",
+						"apiVersion": "shell.fn.crossplane.io/v1alpha1",
 						"kind": "Parameters",
 						"shellCommand": "unknown-shell-command",
 						"stdoutField": "status.atFunction.shell.stdout",
@@ -217,7 +217,7 @@ func TestRunFunction(t *testing.T) {
 				req: &fnv1.RunFunctionRequest{
 					Meta: &fnv1.RequestMeta{Tag: "hello"},
 					Input: resource.MustStructJSON(`{
-						"apiVersion": "template.fn.crossplane.io/v1alpha1",
+						"apiVersion": "shell.fn.crossplane.io/v1alpha1",
 						"kind": "Parameters",
 						"shellCommand": "echo 'success output'; echo 'error output' >&2; exit 1",
 						"stdoutField": "status.atFunction.shell.stdout",
@@ -260,7 +260,7 @@ func TestRunFunction(t *testing.T) {
 				req: &fnv1.RunFunctionRequest{
 					Meta: &fnv1.RequestMeta{Tag: "hello"},
 					Input: resource.MustStructJSON(`{
-						"apiVersion": "template.fn.crossplane.io/v1alpha1",
+						"apiVersion": "shell.fn.crossplane.io/v1alpha1",
 						"kind": "Parameters",
 						"shellEnvVars": [{"key": "TEST_ENV_VAR", "value": "foo"}],
 						"shellCommand": "echo ${TEST_ENV_VAR}",
@@ -302,7 +302,7 @@ func TestRunFunction(t *testing.T) {
 				req: &fnv1.RunFunctionRequest{
 					Meta: &fnv1.RequestMeta{Tag: "hello"},
 					Input: resource.MustStructJSON(`{
-						"apiVersion": "template.fn.crossplane.io/v1alpha1",
+						"apiVersion": "shell.fn.crossplane.io/v1alpha1",
 						"kind": "Parameters",
 						"shellEnvVars": [{"key": "TEST_ENV_VAR", "fieldRef":{"path": "spec.foo", "policy": "Required"}, "type": "FieldRef"}],
 						"shellCommand": "echo ${TEST_ENV_VAR}",
@@ -355,7 +355,7 @@ func TestRunFunction(t *testing.T) {
 				req: &fnv1.RunFunctionRequest{
 					Meta: &fnv1.RequestMeta{Tag: "hello"},
 					Input: resource.MustStructJSON(`{
-						"apiVersion": "template.fn.crossplane.io/v1alpha1",
+						"apiVersion": "shell.fn.crossplane.io/v1alpha1",
 						"kind": "Parameters",
 						"shellEnvVars": [{"key": "TEST_ENV_VAR", "fieldRef":{"path": "spec.bad", "policy": "Optional", "defaultValue": "default"}, "type": "FieldRef"}],
 						"shellCommand": "echo ${TEST_ENV_VAR}",
@@ -397,7 +397,7 @@ func TestRunFunction(t *testing.T) {
 				req: &fnv1.RunFunctionRequest{
 					Meta: &fnv1.RequestMeta{Tag: "hello"},
 					Input: resource.MustStructJSON(`{
-						"apiVersion": "template.fn.crossplane.io/v1alpha1",
+						"apiVersion": "shell.fn.crossplane.io/v1alpha1",
 						"kind": "Parameters",
 						"shellEnvVars": [{"key": "TEST_ENV_VAR", "value": "foo", "type": "bad"}],
 						"shellCommand": "echo ${TEST_ENV_VAR}",
@@ -424,7 +424,7 @@ func TestRunFunction(t *testing.T) {
 				req: &fnv1.RunFunctionRequest{
 					Meta: &fnv1.RequestMeta{Tag: "hello"},
 					Input: resource.MustStructJSON(`{
-						"apiVersion": "template.fn.crossplane.io/v1alpha1",
+						"apiVersion": "shell.fn.crossplane.io/v1alpha1",
 						"kind": "Parameters",
 						"shellEnvVars": [{"key": "TEST_ENV_VAR", "fieldRef":{"policy": "Optional", "defaultValue": "default"}, "type": "FieldRef"}],
 						"shellCommand": "echo ${TEST_ENV_VAR}",
@@ -451,7 +451,7 @@ func TestRunFunction(t *testing.T) {
 				req: &fnv1.RunFunctionRequest{
 					Meta: &fnv1.RequestMeta{Tag: "hello"},
 					Input: resource.MustStructJSON(`{
-						"apiVersion": "template.fn.crossplane.io/v1alpha1",
+						"apiVersion": "shell.fn.crossplane.io/v1alpha1",
 						"kind": "Parameters",
 						"shellCommand": "echo test",
 						"cacheTTL": "5m",
@@ -493,7 +493,7 @@ func TestRunFunction(t *testing.T) {
 				req: &fnv1.RunFunctionRequest{
 					Meta: &fnv1.RequestMeta{Tag: "hello"},
 					Input: resource.MustStructJSON(`{
-						"apiVersion": "template.fn.crossplane.io/v1alpha1",
+						"apiVersion": "shell.fn.crossplane.io/v1alpha1",
 						"kind": "Parameters",
 						"shellCommand": "echo test",
 						"cacheTTL": "5x",

--- a/input/v1alpha1/parameters.go
+++ b/input/v1alpha1/parameters.go
@@ -1,6 +1,6 @@
 // Package v1alpha1 contains the input type for this Function
 // +kubebuilder:object:generate=true
-// +groupName=template.fn.crossplane.io
+// +groupName=shell.fn.crossplane.io
 // +versionName=v1alpha1
 package v1alpha1
 

--- a/package/input/shell.fn.crossplane.io_parameters.yaml
+++ b/package/input/shell.fn.crossplane.io_parameters.yaml
@@ -4,9 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-  name: parameters.template.fn.crossplane.io
+  name: parameters.shell.fn.crossplane.io
 spec:
-  group: template.fn.crossplane.io
+  group: shell.fn.crossplane.io
   names:
     categories:
     - crossplane


### PR DESCRIPTION
# Description of your changes

The apiGroup in the input `template.fn.crossplane.io`, which is the default value from the [template repo](https://github.com/crossplane/function-template-go/blob/f19b8bfb61b56539f7ef254ad337e1f100abbff9/input/v1beta1/input.go#L3). 

To prevent collisions, change the `apiGroup` to `shell.fn.crossplane.io`


I have:

- [x] Read and followed Crossplane's
[contribution process][contribution process]. Also see [docs][docs].
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
