### PR TITLE
fix: improve logging structure for shell commands

### DIFF
--- a/fn.go
+++ b/fn.go
@@ -139,7 +139,7 @@ func (f *Function) RunFunction(_ context.Context, req *fnv1.RunFunctionRequest) 
 		exportCmds = exportCmds + "export " + k + "=\"" + v + "\";"
 	}
 
-	log.Info(shellCmd)
+	log.Debug("Executing shell command", "shellCommand", shellCmd)
 
 	var stdout, stderr bytes.Buffer
 	cmd := shell.Commandf(exportCmds + shellCmd)
@@ -150,7 +150,7 @@ func (f *Function) RunFunction(_ context.Context, req *fnv1.RunFunctionRequest) 
 	sout := strings.TrimSpace(stdout.String())
 	serr := strings.TrimSpace(stderr.String())
 
-	log.Debug(shellCmd, "stdout", sout, "stderr", serr)
+	log.Info("Function output", "tag", req.GetMeta().GetTag(), "stdout", sout, "stderr", serr)
 
 	err = dxr.Resource.SetValue(stdoutField, sout)
 	if err != nil {

--- a/fn_test.go
+++ b/fn_test.go
@@ -19,6 +19,56 @@ import (
 
 const testTagHello = "hello"
 
+type logEntry struct {
+	msg           string
+	keysAndValues []any
+}
+
+type testLogger struct {
+	infoEntries       []logEntry
+	debugEntries      []logEntry
+	withValuesEntries [][]any
+}
+
+func (l *testLogger) Info(msg string, keysAndValues ...any) {
+	l.infoEntries = append(l.infoEntries, logEntry{msg: msg, keysAndValues: keysAndValues})
+}
+
+func (l *testLogger) Debug(msg string, keysAndValues ...any) {
+	l.debugEntries = append(l.debugEntries, logEntry{msg: msg, keysAndValues: keysAndValues})
+}
+
+func (l *testLogger) WithValues(keysAndValues ...any) logging.Logger {
+	l.withValuesEntries = append(l.withValuesEntries, keysAndValues)
+	return l
+}
+
+// assertLogContainsKVs checks that at least one log entry in entries has the specified message and contains all of the specified key-value pairs.
+func assertLogContainsKVs(t *testing.T, entries []logEntry, msg string, wantKVs map[string]any) {
+	t.Helper()
+	for _, entry := range entries {
+		if entry.msg != msg {
+			continue
+		}
+		got := make(map[any]any, len(entry.keysAndValues)/2)
+		for i := 0; i+1 < len(entry.keysAndValues); i += 2 {
+			got[entry.keysAndValues[i]] = entry.keysAndValues[i+1]
+		}
+		for k, want := range wantKVs {
+			v, ok := got[k]
+			if !ok {
+				t.Errorf("log %q: missing key %q (got keys: %v)", msg, k, entry.keysAndValues)
+				continue
+			}
+			if v != want {
+				t.Errorf("log %q key %q: want %q, got %q", msg, k, want, v)
+			}
+		}
+		return
+	}
+	t.Errorf("no log entry with msg %q found (entries: %v)", msg, entries)
+}
+
 func TestRunFunction(t *testing.T) {
 	type args struct {
 		ctx      context.Context
@@ -543,6 +593,118 @@ func TestRunFunction(t *testing.T) {
 
 			if diff := cmp.Diff(tc.want.err, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("%s\nf.RunFunction(...): -want err, +got err:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestRunFunctionLogs(t *testing.T) {
+	type args struct {
+		ctx context.Context
+		req *fnv1.RunFunctionRequest
+	}
+	type wantLog struct {
+		level string // "info" or "debug"
+		msg   string
+		kvs   map[string]any
+	}
+	type want struct {
+		logs []wantLog
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"LogsStdoutOnSuccess": {
+			reason: "Function output log should contain stdout key and empty stderr",
+			args: args{
+				ctx: context.Background(),
+				req: &fnv1.RunFunctionRequest{
+					Meta: &fnv1.RequestMeta{Tag: testTagHello},
+					Input: resource.MustStructJSON(`{
+						"apiVersion": "shell.fn.crossplane.io/v1alpha1",
+						"kind": "Parameters",
+						"shellCommand": "echo foo",
+						"stdoutField": "spec.atFunction.shell.stdout"
+					}`),
+				},
+			},
+			want: want{
+				logs: []wantLog{
+					{
+						level: "debug",
+						msg:   "Executing shell command",
+						kvs: map[string]any{
+							"shellCommand": "echo foo",
+						},
+					},
+					{
+						level: "info",
+						msg:   "Function output",
+						kvs: map[string]any{
+							"tag":    testTagHello,
+							"stdout": "foo",
+							"stderr": "",
+						},
+					},
+				},
+			},
+		},
+		"LogsStderrOnError": {
+			reason: "Function output log should contain stderr when command fails",
+			args: args{
+				ctx: context.Background(),
+				req: &fnv1.RunFunctionRequest{
+					Meta: &fnv1.RequestMeta{Tag: testTagHello},
+					Input: resource.MustStructJSON(`{
+						"apiVersion": "shell.fn.crossplane.io/v1alpha1",
+						"kind": "Parameters",
+						"shellCommand": "echo 'error output' >&2; exit 1",
+						"stdoutField": "status.atFunction.shell.stdout",
+						"stderrField": "status.atFunction.shell.stderr"
+					}`),
+				},
+			},
+			want: want{
+				logs: []wantLog{
+					{
+						level: "debug",
+						msg:   "Executing shell command",
+						kvs: map[string]any{
+							"shellCommand": "echo 'error output' >&2; exit 1",
+						},
+					},
+					{
+						level: "info",
+						msg:   "Function output",
+						kvs: map[string]any{
+							"tag":    testTagHello,
+							"stdout": "",
+							"stderr": "error output",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			logger := &testLogger{}
+			f := &Function{log: logger}
+			_, _ = f.RunFunction(tc.args.ctx, tc.args.req)
+
+			for _, wantLog := range tc.want.logs {
+				switch wantLog.level {
+				case "info":
+					assertLogContainsKVs(t, logger.infoEntries, wantLog.msg, wantLog.kvs)
+				case "debug":
+					assertLogContainsKVs(t, logger.debugEntries, wantLog.msg, wantLog.kvs)
+				default:
+					t.Errorf("unknown log level %q", wantLog.level)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
# Description

This PR improves the logging structure for shell commands by moving verbose command logging to DEBUG level and important output to INFO level with structured key-value pairs. This makes the logs more production-friendly and easier to parse.

This is a continuation of the excellent work started by @cazeaux in PR #129, with the requested improvements from the code review.

## Changes

### 1. Logging Level Changes

**Before:**
- Shell commands logged at INFO level (clutters production logs)
- Output logged at DEBUG level (hidden in production)

**After:**
- Shell commands logged at DEBUG level (verbose details for development)
- Output logged at INFO level (essential information for production)

### 2. Structured Logging

Added structured messages with key-value pairs:

**Debug Log:**
```go
log.Debug("Executing shell command", "shellCommand", shellCmd)
```

**Info Log:**
```go
log.Info("Function output", "tag", req.GetMeta().GetTag(), "stdout", sout, "stderr", serr)
```

### 3. Request Correlation

Added request `tag` to INFO logs for correlating function calls across systems and debugging issues.

## Example Output

### Production (INFO Level Only):
```
2026-08-03T12:13:44.917+0100	INFO	Running function	{"tag": "f4156cf25f5f05d9e07d56c5ed61069984b2520c7ba4589c3c039413d0b80a97"}
2026-08-03T12:13:44.927+0100	INFO	Function output	{"tag": "f4156cf...", "stdout": "Hello from shell", "stderr": ""}
```

### Development (DEBUG Level):
```
2026-08-03T12:13:44.917+0100	INFO	Running function	{"tag": "f4156cf25f5f05d9e07d56c5ed61069984b2520c7ba4589c3c039413d0b80a97"}
2026-08-03T12:13:44.919+0100	DEBUG	Executing shell command	{"shellCommand": "echo ${ECHO}|base64 -d|sed s/^h/H/\n"}
2026-08-03T12:13:44.927+0100	INFO	Function output	{"tag": "f4156cf...", "stdout": "Hello from shell", "stderr": ""}
```

## Testing

### Unit Tests
Added comprehensive logging tests:
- `testLogger` implementation for capturing log entries
- `assertLogContainsKVs` helper for validation
- `TestRunFunctionLogs` with success and error scenarios

All tests pass:
```
=== RUN   TestRunFunctionLogs
=== RUN   TestRunFunctionLogs/LogsStdoutOnSuccess
=== RUN   TestRunFunctionLogs/LogsStderrOnError
--- PASS: TestRunFunctionLogs (0.01s)
PASS
coverage: 69.9% of statements
```

### Live Verification
Tested with real examples using:
- `go run . --insecure --debug` (function in dev mode)
- `crossplane composition render` (rendering examples)
- Verified both stdout-only and stdout+stderr scenarios
- Confirmed structured logging format
- Validated request tag correlation

## Use Cases

### Monitoring & Alerting
```bash
# Find errors (non-empty stderr)
cat logs.json | jq 'select(.stderr != "")'

# Correlate by request tag
cat logs.json | jq 'select(.tag == "f4156cf...")'

# Filter by XR name
cat logs.json | jq 'select(.["oxr-name"] == "my-resource")'
```

### Production Benefits
- Clean, structured logs suitable for log aggregators
- Request correlation for distributed tracing
- Security: sensitive commands not logged at INFO level
- Easy filtering and alerting rules
- Machine-parseable for automated analysis

## Attribution

This PR builds upon the original work by **@cazeaux** (Stéphane Cazeaux) in PR #129.

**Enhancements added:**
- Structured message for DEBUG log (as requested in review)
- Added request tag to INFO log for correlation
- Resolved merge conflicts with current main
- Added comprehensive test coverage
- Live verification with examples

Fixes #128

---

I have:

- [x] Read and followed Crossplane's [contribution process][contribution process]. Also see [docs][docs].
- [x] Added or updated unit tests for my change.
- [x] Live tested with development function and render examples
- [x] Properly attributed original author

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute