### PR TITLE
chore: bump version references to v0.7.0

### DIFF
--- a/example/aws/functions-remote.yaml
+++ b/example/aws/functions-remote.yaml
@@ -7,7 +7,7 @@ metadata:
 #    render.crossplane.io/runtime: Development
 spec:
   # This is ignored when using the Development runtime.
-  package: xpkg.upbound.io/crossplane-contrib/function-shell:v0.6.0
+  package: xpkg.upbound.io/crossplane-contrib/function-shell:v0.7.0
 ---
 apiVersion: pkg.crossplane.io/v1
 kind: Function

--- a/example/aws/functions.yaml
+++ b/example/aws/functions.yaml
@@ -8,7 +8,7 @@ metadata:
     #render.crossplane.io/runtime: Development
 spec:
   # This is ignored when using the Development runtime.
-  package: xpkg.upbound.io/crossplane-contrib/function-shell:v0.6.0
+  package: xpkg.upbound.io/crossplane-contrib/function-shell:v0.7.0
 ---
 apiVersion: pkg.crossplane.io/v1
 kind: Function

--- a/example/datadog-dashboard-ids/functions.yaml
+++ b/example/datadog-dashboard-ids/functions.yaml
@@ -8,7 +8,7 @@ metadata:
     render.crossplane.io/runtime: Development
 spec:
   # This is ignored when using the Development runtime.
-  package: xpkg.upbound.io/crossplane-contrib/function-shell:v0.6.0
+  package: xpkg.upbound.io/crossplane-contrib/function-shell:v0.7.0
   packagePullPolicy: Always
   runtimeConfigRef:
     apiVersion: pkg.crossplane.io/v1beta1

--- a/example/echo/functions.yaml
+++ b/example/echo/functions.yaml
@@ -8,4 +8,4 @@ metadata:
     render.crossplane.io/runtime: Development
 spec:
   # This is ignored when using the Development runtime.
-  package: xpkg.upbound.io/crossplane-contrib/function-shell:v0.6.0
+  package: xpkg.upbound.io/crossplane-contrib/function-shell:v0.7.0

--- a/example/fieldRef/functions.yaml
+++ b/example/fieldRef/functions.yaml
@@ -8,4 +8,4 @@ metadata:
     # render.crossplane.io/runtime: Development
 spec:
   # This is ignored when using the Development runtime.
-  package: xpkg.upbound.io/crossplane-contrib/function-shell:v0.6.0
+  package: xpkg.upbound.io/crossplane-contrib/function-shell:v0.7.0


### PR DESCRIPTION
## Summary

- Update all example function references from v0.6.0 to v0.7.0 for the upcoming release

### Files updated:
- example/aws/functions.yaml
- example/aws/functions-remote.yaml
- example/datadog-dashboard-ids/functions.yaml
- example/echo/functions.yaml
- example/fieldRef/functions.yaml

## Test plan
- [x] Verified all version references updated with `grep -rn "function-shell:v"`
- [x] No remaining v0.6.0 references

🤖 Generated with [Claude Code](https://claude.com/claude-code)